### PR TITLE
Change starting and ending altitudes in example to actual altudes of the airports

### DIFF
--- a/discrete_signals.html
+++ b/discrete_signals.html
@@ -126,7 +126,7 @@
 				  	</p>
 
 				  	<p>
-				  	We can refer to a particular sample by index. For example, <span class="inlineexample"> altitude[4] </span> is <span class="inlineexample">35,000</span> and <span class="inlineexample"> altitude[8] </span> is <span class="inlineexample">27,000</span>. Note that the indexes start from zero. The first sample is at index <span class="inlineexample">0</span>, the second sample is at index <span class="inlineexample">1</span>, the third at index <span class="inlineexample">2</span>, and so on.
+				  	We can refer to a particular sample by index. For example, <span class="inlineexample"> altitude[4] </span> is <span class="inlineexample">35,000</span> and <span class="inlineexample"> altitude[8] </span> is <span class="inlineexample">27,000</span>. Note that the indexes start from zero. The first sample is at index <span class="inlineexample">291</span>, the second sample is at index <span class="inlineexample">1</span>, the third at index <span class="inlineexample">2</span>, and so on.
 				  	</p>
 	  			</td>
 				<td class="figureExplanation" style="">

--- a/discrete_signals.html
+++ b/discrete_signals.html
@@ -109,7 +109,7 @@
 
 	  				<p class="example" style="font-family: lato; color: #333;">
 				  		<b>
-				  		altitude = [0,
+				  		altitude = [291,
 						6000,
 						15000,
 						20000,
@@ -121,7 +121,7 @@
 						12000,
 						3500,
 						1200,
-						0]
+						122]
 						</b>
 				  	</p>
 

--- a/js/plane_sampling.js
+++ b/js/plane_sampling.js
@@ -1,6 +1,6 @@
 var PLANE_2 = (function() {
 var lineData = [
-  {x: 0, y: 0}
+  {x: 0, y: 291}    // Elevation AMSL at ORY
 , {x: 10, y: 6000}
 , {x: 20, y: 15000}
 , {x: 30, y: 20000}
@@ -13,7 +13,7 @@ var lineData = [
 , {x: 90, y: 12000}
 , {x: 100, y: 3500}
 , {x: 110, y: 1200}
-, {x: 120, y: 0}
+, {x: 120, y: 122}  // Elevation AMSL at TXL
 ];
 
 var canvasWidth = 700;


### PR DESCRIPTION
In the hopes of eliminating potential confusion around _"0 the index"_ and _"0 the contents of index 0"_, I changed the contents of index 0 to the altitude of the ORY airport in Paris. Maybe this will make the text more clear? I don't have a big attachment to this change, so feel free to deny it.
