### PR TITLE
Display correct coordinates and magnitude for initial point

### DIFF
--- a/js/complex_plane.js
+++ b/js/complex_plane.js
@@ -113,8 +113,8 @@ var circle = vis.append('svg:circle')
 //   .style("-webkit-user-select", "none")
 //   .text("φ = ");
 
-var pointX = 0.5;
-var pointY = 0.5;
+var pointX = Math.sqrt(2) / 2;
+var pointY = Math.sqrt(2) / 2;
 
 var point = vis.append('svg:circle')
   .attr('cx', xRange(pointX))


### PR DESCRIPTION
Right now it displays the initial point textually as "+ 0.50 + 0.50 i" with magnitude 0.71. But graphically the initial point is actually at "+ 0.71 + 0.71 i" with magnitude 1.00. This fixes the initial textual description.
