### PR TITLE
Correct duplicate slider ID.

### DIFF
--- a/dotproduct3.html
+++ b/dotproduct3.html
@@ -136,7 +136,7 @@
 
 								<div class="controls" width="180">
 									<label id="frequency" for=simpleCorrelationFreq>Frequency</label><br/>
-									<input type=range min=1 max=5 value=1 id=simpleCorrelationOffset step=1 oninput="updateSimpleCorrelationFreq(value);"
+									<input type=range min=1 max=5 value=1 id=simpleCorrelationFreq step=1 oninput="updateSimpleCorrelationFreq(value);"
 									onMouseDown="" onMouseUp="" style="width: 150px"><br/>
 
 									<label id="phaseShift" for=simpleCorrelationOffset>Phase Shift</label><br/>

--- a/dotproduct4.html
+++ b/dotproduct4.html
@@ -147,7 +147,7 @@
 									onMouseDown="" onMouseUp="" style="width: 150px"><br/>
 
 									<label id="frequency" for=simpleCorrelationFreq>Frequency</label><br/>
-									<input type=range min=1 max=5 value=1 id=simpleCorrelationOffset step=1 oninput="updateSimpleCorrelationFreq(value);"
+									<input type=range min=1 max=5 value=1 id=simpleCorrelationFreq step=1 oninput="updateSimpleCorrelationFreq(value);"
 									onMouseDown="" onMouseUp="" style="width: 150px">
 								</div>
 							</td>


### PR DESCRIPTION
It might seem like a trivial issue, but my browser (Firefox 45, if it matters) wouldn't let the slider go to _exactly_ 90°, so I went to the console to manually put it at the right mark... and couldn't. Judging by the `for` attribute of the preceding label, this is the correct ID.
