### PR TITLE
Remove a dittography from the text

### DIFF
--- a/sine_wave_properties.html
+++ b/sine_wave_properties.html
@@ -214,7 +214,7 @@
 	  				<br/>
 
 	  				<p>
-					Sine waves are utterly fascinating. Their peculiar nature makes them particularly well suited to act as the “atomic” components of complex signals. I’d encourage you to play around with sinusoids and the the trigonometric identities. Successful signal processing practice requires being somewhat intellectually intimate with sine waves. You'll constantly use them as test signals and ground-truths when writing and reasoning about signal processing algorithms.
+					Sine waves are utterly fascinating. Their peculiar nature makes them particularly well suited to act as the “atomic” components of complex signals. I’d encourage you to play around with sinusoids and the trigonometric identities. Successful signal processing practice requires being somewhat intellectually intimate with sine waves. You'll constantly use them as test signals and ground-truths when writing and reasoning about signal processing algorithms.
 					</p>
 	  			</td>
 				<td class="figureExplanation" style="">


### PR DESCRIPTION
A "the" word was repeated two times and was not meant for stressing or
whatever, it was just a typographical error (dittography).