### PR TITLE
Fixes truncated graphic

### DIFF
--- a/complex.html
+++ b/complex.html
@@ -119,7 +119,7 @@
 				<table width="750px">
 						<tr>
 							<td>
-								<svg id="complexintro" class="svgWithText" width="255" height="200" style="cursor: pointer; padding: 10px; margin-left: 230px"></svg>
+								<svg id="complexintro" class="svgWithText" width="255" height="210" style="cursor: pointer; padding: 10px; margin-left: 230px"></svg>
 								<script type="text/javascript" src="js/complex_intro.js"></script>
   							</td>
 						</tr>


### PR DESCRIPTION
Hey Jack,

The imaginary number rotation graphic on [this page](https://jackschaedler.github.io/circles-sines-signals/complex.html) is cut off on Firefox for me like this:

![imaginary-rotation](https://user-images.githubusercontent.com/7118950/46967712-9c9b1c80-d0b1-11e8-9410-5789495da654.png)

I've simply increased the height in this PR.

Cheers,

James Kneafsey
