### PR TITLE
Update dot product subheading according to selected vector

### DIFF
--- a/dotproduct.html
+++ b/dotproduct.html
@@ -119,7 +119,7 @@
 
 				<br/>
 				<table>
-						<tr class="figureCaption">
+						<tr class="figureCaption" id="figure1">
 							<td width="100%">
 							<b>Figure 1.</b>&nbsp; Geometric Interpretation of the Dot Product<br/><sub>Click and drag to change the endpoint of the pink vector</sub>
 							</td>

--- a/js/dot_product_2d.js
+++ b/js/dot_product_2d.js
@@ -246,8 +246,11 @@ function onVectorChangeButton()
 {
   activeVectorIsB = !activeVectorIsB;
   vectorButton.text("Mouse Moves " + (activeVectorIsB ? "B" : "A"));
+  vectorSubheading.text("Click and drag to change the endpoint of the "
+                        + (activeVectorIsB ? "pink" : "blue") + " vector"); 
 }
 
+var vectorSubheading = d3.select("#figure1").select("sub");
 
 var vectorButton = d3.select('#wrapper').insert("button", ":first-child")
   .style("position", "absolute")

--- a/js/dot_product_2d.js
+++ b/js/dot_product_2d.js
@@ -245,7 +245,7 @@ var activeVectorIsB = true;
 function onVectorChangeButton()
 {
   activeVectorIsB = !activeVectorIsB;
-  vectorButton.text("Mouse Moves " + (activeVectorIsB ? "B" : "A"));
+  vectorButton.text("Mouse Moves " + (activeVectorIsB ? "Pink" : "Blue"));
   vectorSubheading.text("Click and drag to change the endpoint of the "
                         + (activeVectorIsB ? "pink" : "blue") + " vector"); 
 }
@@ -255,9 +255,9 @@ var vectorSubheading = d3.select("#figure1").select("sub");
 var vectorButton = d3.select('#wrapper').insert("button", ":first-child")
   .style("position", "absolute")
   .style("top", 135)
-  .style("left", 490)
+  .style("left", 480)
   .style("height", 25)
-  .text("Mouse Moves B")
+  .text("Mouse Moves Pink")
   .on("click", onVectorChangeButton);
 
 var mouseIsDown = false;


### PR DESCRIPTION
Hi! I was revisiting this amazing resource and noticed that in the dot product page, toggling "Mouse Moves A"/"Mouse Moves B" doesn't update Figure 1's subheading accordingly.

This is such a tiny, tiny thing, but figured I'd bring it up anyways -- I've put in a simple change in this PR.

(I also adjusted the button text to say "Pink"/"Blue" instead of "A"/"B" for slightly more consistency with the subheading, but could see "A"/"B" still making sense given the notation and example on the same page.)

In any case, feel free to ignore since this is super minor, and thanks so much for providing this incredible work!!

--------

Here's a video comparison of before vs. after, for easy reference:

**Before:**

https://user-images.githubusercontent.com/2868935/176601122-d4fc38b6-ff80-46a7-b543-5eac29dd3e6e.mp4



**After:**

https://user-images.githubusercontent.com/2868935/176601132-a6428802-b5fb-4cd6-84de-ebd6530bda9f.mp4


